### PR TITLE
esn-frontend-common-libs#78: Marked 'profile.details.view' as the default state

### DIFF
--- a/src/linagora.esn.profile/app/app.routes.js
+++ b/src/linagora.esn.profile/app/app.routes.js
@@ -55,7 +55,8 @@
             'details@profile.details': {
               template: '<profile-show-details user="user" />'
             }
-          }
+          },
+          default: true
         })
         .state('profile.details.followers', {
           url: '/followers',


### PR DESCRIPTION
Partially resolves https://github.com/OpenPaaS-Suite/esn-frontend-common-libs/issues/78. Please also refer to https://github.com/OpenPaaS-Suite/esn-frontend-common-libs/pull/87.

- Demo: _to be updated..._