### PR TITLE
#46 Hide search advanced component

### DIFF
--- a/assets/index.pug
+++ b/assets/index.pug
@@ -7,6 +7,9 @@ html
     meta(name="viewport", content="width=device-width, initial-scale=1")
     meta(name="theme-color", content="#0C7CD5")
     script(src="/socket.io/socket.io.js")
-
+    style(type='text/css').
+      esn-search-header{
+        display: none;
+      }
   body.container-fluid.ng-cloak(ng-app="esnApp", ng-controller="sessionInitESNController", device-detector, ng-class="{ 'grabbable': esnIsDragging }")
     #wrap(ng-include='session.template')


### PR DESCRIPTION
This search advanced component is supposed to be brought back according to this issue: https://github.com/OpenPaaS-Suite/esn-frontend-account/issues/47
Remove the CSS style for esn-search-header in `index.pug` to unhide it